### PR TITLE
Reset controls on video source change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,6 +38,7 @@ function App() {
     position,
     startPosition,
     endPosition,
+    resetBoundaries,
   } = useVideoActions();
 
   return (
@@ -47,7 +48,8 @@ function App() {
         <Player
           videoRef={videoRef}
           source={videoSource}
-          videoOnTimeUpdate={videoOnTimeUpdate}
+          onVideoTimeUpdate={videoOnTimeUpdate}
+          onVideoLoadStart={resetBoundaries}
         />
         <VideoSpeedControls
           hasVideo={!!videoSource}

--- a/src/components/player/player.js
+++ b/src/components/player/player.js
@@ -3,7 +3,8 @@ import "./player.css";
 export const Player = ({
   videoRef = null,
   source = null,
-  videoOnTimeUpdate = () => {},
+  onVideoTimeUpdate = () => {},
+  onVideoLoadStart = () => {},
   controls = true,
 }) => {
   return (
@@ -12,7 +13,8 @@ export const Player = ({
         <video
           key={`source=${source}`}
           ref={videoRef}
-          onTimeUpdate={videoOnTimeUpdate}
+          onTimeUpdate={onVideoTimeUpdate}
+          onLoadStart={onVideoLoadStart}
           controls={controls}
           autoPlay
         >

--- a/src/components/player/player.js
+++ b/src/components/player/player.js
@@ -5,6 +5,7 @@ export const Player = ({
   source = null,
   onVideoTimeUpdate = () => {},
   onVideoLoadStart = () => {},
+  onLoaded = () => {},
   controls = true,
 }) => {
   return (
@@ -15,6 +16,7 @@ export const Player = ({
           ref={videoRef}
           onTimeUpdate={onVideoTimeUpdate}
           onLoadStart={onVideoLoadStart}
+          onLoadedData={onLoaded}
           controls={controls}
           autoPlay
         >

--- a/src/components/video-markers/video-markers.css
+++ b/src/components/video-markers/video-markers.css
@@ -1,7 +1,6 @@
 .video-markers {
   position: relative;
   margin: 0 24px;
-  padding: 0 4px;
   border: solid 1px #000;
   height: 40px;
 }
@@ -18,7 +17,7 @@
 .video-markers__start:before,
 .video-markers__end:before {
   position: absolute;
-  content: '';
+  content: "";
   width: 24px;
   height: 40px;
   background-color: red;

--- a/src/components/video-markers/video-markers.js
+++ b/src/components/video-markers/video-markers.js
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState, useEffect } from "react";
 import Draggable from "react-draggable";
 
 import "./video-markers.css";
@@ -6,9 +6,8 @@ import "./video-markers.css";
 import { getPosition } from "../../utils";
 
 export const VideoMarkers = ({
-  videoBuffer,
-  position,
-  changePosition = () => {},
+  startPosition,
+  endPosition,
   changeStartPosition = () => {},
   changeEndPosition = () => {},
 }) => {
@@ -38,6 +37,7 @@ export const VideoMarkers = ({
         axis="x"
         {...dragStartHandlers}
         bounds={{ left: 0, right: 640 }}
+        position={{ x: 640 * startPosition, y: 0 }}
       >
         <div className="video-markers__start" ref={startRef}></div>
       </Draggable>
@@ -45,6 +45,7 @@ export const VideoMarkers = ({
         axis="x"
         {...dragEndHandlers}
         bounds={{ left: -640, right: 0 }}
+        position={{ x: 640 * (endPosition - 1), y: 0 }}
       >
         <div className="video-markers__end" ref={endRef}></div>
       </Draggable>

--- a/src/components/video-markers/video-markers.js
+++ b/src/components/video-markers/video-markers.js
@@ -1,9 +1,13 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef } from "react";
 import Draggable from "react-draggable";
 
 import "./video-markers.css";
 
-import { getPosition } from "../../utils";
+export const getPosition = (track, pointer) => {
+  const left1 = track.getBoundingClientRect().left;
+  const left2 = pointer.getBoundingClientRect().left;
+  return left2 - left1;
+};
 
 export const VideoMarkers = ({
   startPosition,
@@ -33,20 +37,10 @@ export const VideoMarkers = ({
 
   return (
     <div className="video-markers" ref={trackRef}>
-      <Draggable
-        axis="x"
-        {...dragStartHandlers}
-        bounds={{ left: 0, right: 640 }}
-        position={{ x: 640 * startPosition, y: 0 }}
-      >
+      <Draggable axis="x" {...dragStartHandlers} bounds={"parent"}>
         <div className="video-markers__start" ref={startRef}></div>
       </Draggable>
-      <Draggable
-        axis="x"
-        {...dragEndHandlers}
-        bounds={{ left: -640, right: 0 }}
-        position={{ x: 640 * (endPosition - 1), y: 0 }}
-      >
+      <Draggable axis="x" {...dragEndHandlers} bounds={"parent"}>
         <div className="video-markers__end" ref={endRef}></div>
       </Draggable>
     </div>

--- a/src/components/video-wave/video-wave.js
+++ b/src/components/video-wave/video-wave.js
@@ -12,7 +12,6 @@ export const VideoWave = ({
       <Waveform
         buffer={videoBuffer}
         height={80}
-        width={640}
         markerStyle={{ color: "#ffffff", width: 1 }}
         onPositionChange={changePosition}
         plot="bar"

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,1 @@
+export { useVideoState } from "./use-video-state";

--- a/src/hooks/use-video-actions.js
+++ b/src/hooks/use-video-actions.js
@@ -1,20 +1,17 @@
 import { useRef, useState } from "react";
 
+const videoInitialState = {
+  time: 0,
+  position: 0,
+};
+
 export const useVideoActions = () => {
   const videoRef = useRef();
-  const [video, setVideo] = useState({
-    time: 0,
-    position: 0,
-  });
+  const [video, setVideo] = useState(videoInitialState);
 
   const [playbackRate, setPlaybackRate] = useState(1);
   const [startPosition, setStartPosition] = useState(0);
   const [endPosition, setEndPosition] = useState(1);
-
-  const resetBoundaries = () => {
-    setStartPosition(0);
-    setEndPosition(1);
-  };
 
   const setCurrentTime = (time) => (videoRef.current.currentTime = time);
 
@@ -71,6 +68,13 @@ export const useVideoActions = () => {
     setEndPosition(nextPosition);
   };
 
+  const resetVideoControls = () => {
+    setVideo(videoInitialState);
+    setPlaybackRate(1);
+    setStartPosition(0);
+    setEndPosition(1);
+  };
+
   return {
     videoRef,
     playbackRate,
@@ -83,6 +87,6 @@ export const useVideoActions = () => {
     position: video.position,
     startPosition,
     endPosition,
-    resetBoundaries,
+    resetVideoControls,
   };
 };

--- a/src/hooks/use-video-actions.js
+++ b/src/hooks/use-video-actions.js
@@ -11,6 +11,11 @@ export const useVideoActions = () => {
   const [startPosition, setStartPosition] = useState(0);
   const [endPosition, setEndPosition] = useState(1);
 
+  const resetBoundaries = () => {
+    setStartPosition(0);
+    setEndPosition(1);
+  };
+
   const setCurrentTime = (time) => (videoRef.current.currentTime = time);
 
   const changePlaybackRate = (rate) => {
@@ -78,5 +83,6 @@ export const useVideoActions = () => {
     position: video.position,
     startPosition,
     endPosition,
+    resetBoundaries,
   };
 };

--- a/src/hooks/use-video-state.js
+++ b/src/hooks/use-video-state.js
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export const useVideoState = () => {
+  const [isVideoLoaded, setVideoLoadedState] = useState(false);
+
+  const resetVideoState = () => {
+    setVideoLoadedState(false);
+  };
+
+  return {
+    isVideoLoaded,
+    resetVideoState,
+    setVideoLoadedState,
+  };
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,14 +12,14 @@ export const getAudioBuffer = async (path) => {
   const response = await fetch(path);
   const audioData = await response.arrayBuffer();
   return new Promise((resolve, reject) => {
-    audioContext.decodeAudioData(audioData, (buffer) => {
-      return resolve(buffer);
-    });
+    audioContext.decodeAudioData(
+      audioData,
+      (buffer) => {
+        resolve(buffer);
+      },
+      (err) => {
+        reject(err);
+      }
+    );
   });
-};
-
-export const getPosition = (track, pointer) => {
-  const left1 = track.getBoundingClientRect().left;
-  const left2 = pointer.getBoundingClientRect().left;
-  return left2 - left1;
 };


### PR DESCRIPTION
This PR allows resetting the external video controls when the video source changes. 

PS: In the future, we need to consolidate all the states related to the video and audio buffer, maybe with an useReducer hook, in aim to control the loading state in a more suitable way and exhibit a loading component while these processes are running.